### PR TITLE
Add flash error messages

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -4,13 +4,12 @@ class EntriesController < ApplicationController
   end
 
   def create
-    @entry = Entry.build_entry(entry_params)
+    @entry = Entry.create_entry(entry_params)
 
     if @entry.valid?
-      @entry.save
       redirect_to entry_path(@entry)
     else
-      flash[:errors] = @entry.errors.full_messages
+      flash.now[:error] = @entry.errors.full_messages
       render :new
     end
   end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -1,14 +1,17 @@
 class Entry < ApplicationRecord
-  validates :user, uniqueness: { scope: :date }
-  validates :date, presence: true
+  validates :date,
+    uniqueness: { scope: :user, message: ": Already an entry for this date" }
+   validates :date, presence: true
 
   has_many :goals, dependent: :destroy
   belongs_to :user
 
-  def self.build_entry(params)
+  def self.create_entry(params)
     ActiveRecord::Base.transaction do
-      entry = create({ date: params[:date], user: params[:user] })
-      entry.add_goals(params[:goals])
+      entry = new({ date: params[:date], user: params[:user] })
+      if entry.save
+        entry.add_goals(params[:goals])
+      end
       entry
     end
   end

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,7 +1,7 @@
 <% if flash.any? %>
   <div class="flashes">
-    <% user_facing_flashes.each do |key, value| -%>
+    <% user_facing_flashes.each do |key, value| %>
       <div class="flash-<%= key %>"><%= value %></div>
-    <% end -%>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -1,7 +1,7 @@
 <h1>create a new entry</h1>
 
 <%= form_for @entry, url: {action: "create"} do |f| %>
-  <input type="date" id="goal-date" name="entry[date]"/>
+  <input type="date" id="goal-date" name="entry[date]" value="<%= @entry.date %>"/>
   <% 3.times do |i| %>
     <% goal_id = "goal-#{i + 1}" %>
     <label for="<%= goal_id %>"><%= "Goal #{i + 1}" %></label>

--- a/db/migrate/20180403131633_add_foreign_key_to_goals.rb
+++ b/db/migrate/20180403131633_add_foreign_key_to_goals.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToGoals < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key :goals, :entries
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180330153051) do
+ActiveRecord::Schema.define(version: 20180403131633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,4 +57,5 @@ ActiveRecord::Schema.define(version: 20180330153051) do
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end
 
+  add_foreign_key "goals", "entries"
 end

--- a/spec/features/user_creates_todays_entry_spec.rb
+++ b/spec/features/user_creates_todays_entry_spec.rb
@@ -7,22 +7,42 @@ RSpec.feature "User creates a journal entry" do
     goal2 = Faker::Lorem.sentence
     goal3 = Faker::Lorem.sentence
     todays_date = Date.today
+    entry_params = { date: todays_date, goal1: goal1, goal2: goal2, goal3: goal3 }
 
     sign_in
-    visit new_entry_path
-    fill_in "goal-date", with: todays_date
-    fill_in "Goal 1", with: goal1
-    fill_in "Goal 2", with: goal2
-    fill_in "Goal 3", with: goal3
-    click_on "Create Entry"
+    create_entry(entry_params)
 
     expect(page).to have_goal_summary(goal1)
     expect(page).to have_goal_summary(goal2)
     expect(page).to have_goal_summary(goal3)
     expect(page).to have_content(todays_date)
   end
+
+  scenario "renders error message when validation fails" do
+    todays_date = Date.today
+
+    sign_in
+    create_entry(date: todays_date)
+    create_entry(date: todays_date)
+
+    error_message = "Date : Already an entry for this date"
+    expect(page).to have_error_message(error_message)
+  end
+end
+
+def create_entry(date: Date.today, goal1: nil, goal2: nil, goal3: nil)
+  visit new_entry_path
+  fill_in "goal-date", with: date
+  fill_in "Goal 1", with: goal1 || Faker::Lorem.sentence
+  fill_in "Goal 2", with: goal2 || Faker::Lorem.sentence
+  fill_in "Goal 3", with: goal3 || Faker::Lorem.sentence
+  click_on "Create Entry"
 end
 
 def have_goal_summary(goal)
   have_css(".goal-summary", text: goal)
+end
+
+def have_error_message(message)
+  have_css(".flash-error", text: message)
 end

--- a/spec/support/features/clearance_helpers.rb
+++ b/spec/support/features/clearance_helpers.rb
@@ -3,7 +3,7 @@ module Features
     def reset_password_for(email)
       visit new_password_path
       fill_in "password_email", with: email
-      click_button "Reset password" 
+      click_button "Reset password"
     end
 
     def sign_in


### PR DESCRIPTION
Before when a user entered invalid form data for creating a new entry,
no helpful errors would be shown.  This add flash errors for throw
validation errors. It also fixed a bug where goals for unsaved entries
would try to be made.