### PR TITLE
Introduce form object patter for new entry form

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -1,15 +1,15 @@
 class EntriesController < ApplicationController
   def new
-    @entry = Entry.new
+    @entry_form = EntryForm.new
   end
 
   def create
-    @entry = Entry.create_entry(entry_params)
+    @entry_form = EntryForm.new(entry_form_params)
 
-    if @entry.valid?
-      redirect_to entry_path(@entry)
+    if @entry_form.save
+      redirect_to entry_path(@entry_form.entry)
     else
-      flash.now[:error] = @entry.errors.full_messages
+      flash.now[:error] = @entry_form.errors.full_messages
       render :new
     end
   end
@@ -20,10 +20,12 @@ class EntriesController < ApplicationController
 
   private
 
-  def entry_params
+  def entry_form_params
     params.
-      require(:entry).
-      permit(:date, goals: []).
-      merge(user: current_user)
+      require(:entry_form).
+      permit(:date, goal_descriptions: []).
+      merge(user: current_user).
+      to_h.
+      symbolize_keys
   end
 end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -5,24 +5,4 @@ class Entry < ApplicationRecord
 
   has_many :goals, dependent: :destroy
   belongs_to :user
-
-  def self.create_entry(params)
-    ActiveRecord::Base.transaction do
-      entry = new({ date: params[:date], user: params[:user] })
-      if entry.save
-        entry.add_goals(params[:goals])
-      end
-      entry
-    end
-  end
-
-  def add_goals(descriptions_array)
-    descriptions_array.each do |description|
-      add_goal(description)
-    end
-  end
-
-  def add_goal(description)
-    Goal.create(description: description, entry: self)
-  end
 end

--- a/app/models/entry_form.rb
+++ b/app/models/entry_form.rb
@@ -1,0 +1,66 @@
+class EntryForm
+  include ActiveModel::Model
+  extend ActiveModel::Naming
+
+  def initialize(date: nil, user: nil, goal_descriptions: Array.new(3) {""})
+    @date = date
+    @user = user
+    @goal_descriptions = goal_descriptions
+    @entry = Entry.new(date: date, user: user)
+    @goals = @goal_descriptions.map { |description| Goal.new(description: description) }
+  end
+
+  attr_reader :entry, :goals, :date
+
+  def persisted?
+    false
+  end
+
+  def save
+    if valid?
+      persist!
+      true
+    else
+      add_error_messages
+      false
+    end
+  end
+
+  private
+
+  def valid?
+    entry_validation = entry.valid?
+    goals_validations = goals.all?(&:valid?)
+    entry_validation && goals_validations
+  end
+
+  def persist!
+    ActiveRecord::Base.transaction do
+      entry.save!
+      create_goals_for_entry!
+    end
+  end
+
+  def create_goals_for_entry!
+    goals.each { |goal| goal.update!(entry: entry) }
+  end
+
+  def add_error_messages
+    add_entry_error_messages
+    add_goal_error_messages
+  end
+
+  def add_entry_error_messages
+    entry.errors.full_messages.each do |message|
+      errors.add(:entry, message)
+    end
+  end
+
+  def add_goal_error_messages
+    goals.each do |goal|
+      goal.errors.full_messages.each do |message|
+        errors.add(:goal, message)
+      end
+    end
+  end
+end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,4 +1,5 @@
 class Goal < ApplicationRecord
   validates_length_of :description, maximum: 255
-  belongs_to :entry
+
+  belongs_to :entry, optional: true
 end

--- a/app/views/entries/new.html.erb
+++ b/app/views/entries/new.html.erb
@@ -1,11 +1,21 @@
 <h1>create a new entry</h1>
 
-<%= form_for @entry, url: {action: "create"} do |f| %>
-  <input type="date" id="goal-date" name="entry[date]" value="<%= @entry.date %>"/>
-  <% 3.times do |i| %>
-    <% goal_id = "goal-#{i + 1}" %>
-    <label for="<%= goal_id %>"><%= "Goal #{i + 1}" %></label>
-    <input type="text" name="entry[goals][]" id="<%= goal_id %>"/>
+<%= form_for @entry_form, url: {action: "create"} do |f| %>
+  <input
+    type="date"
+    id="entry-date"
+    name="entry_form[date]"
+    value="<%= @entry_form.date %>"
+   />
+  <% @entry_form.goals.each_with_index do |goal, idx| %>
+    <% goal_id = "goal-#{idx + 1}" %>
+    <label for="<%= goal_id %>"><%= "Goal #{idx + 1}" %></label>
+    <input
+      type="text"
+      name="entry_form[goal_descriptions][]"
+      id="<%= goal_id %>"
+      value="<%= goal.description %>"
+    />
   <% end %>
   <%= f.submit %>
 <% end %>

--- a/spec/features/user_creates_todays_entry_spec.rb
+++ b/spec/features/user_creates_todays_entry_spec.rb
@@ -18,21 +18,31 @@ RSpec.feature "User creates a journal entry" do
     expect(page).to have_content(todays_date)
   end
 
-  scenario "renders error message when validation fails" do
+  scenario "renders error message when entry is invalid" do
     todays_date = Date.today
 
     sign_in
     create_entry(date: todays_date)
     create_entry(date: todays_date)
 
-    error_message = "Date already has an entry"
+    error_message = "Entry Date already has an entry"
+    expect(page).to have_error_message(error_message)
+  end
+
+  scenario "renders error message when goal is invalid" do
+    goal_which_is_too_long = "i"*256
+
+    sign_in
+    create_entry(goal1: goal_which_is_too_long)
+
+    error_message = "Goal Description is too long (maximum is 255 characters)"
     expect(page).to have_error_message(error_message)
   end
 end
 
 def create_entry(date: Date.today, goal1: nil, goal2: nil, goal3: nil)
   visit new_entry_path
-  fill_in "goal-date", with: date
+  fill_in "entry-date", with: date
   fill_in "Goal 1", with: goal1 || Faker::Lorem.sentence
   fill_in "Goal 2", with: goal2 || Faker::Lorem.sentence
   fill_in "Goal 3", with: goal3 || Faker::Lorem.sentence

--- a/spec/models/entry_form_spec.rb
+++ b/spec/models/entry_form_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "EntryForm" do
+  it "initializes with a blank entry and three blank goals" do
+    entry_form = EntryForm.new
+
+    expect(entry_form.entry).to be_a_kind_of(Entry)
+    expect(entry_form.goals.length).to eq 3
+    expect(entry_form.goals.first).to be_a_kind_of(Goal)
+  end
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -3,31 +3,13 @@ require 'rails_helper'
 RSpec.describe Entry, type: :model do
   describe "Validations" do
     subject { create(:entry) }
-    it { should validate_uniqueness_of(:date).scoped_to(:user_id).with_message("already has an entry") }
+    it do
+      should validate_uniqueness_of(:date).
+        scoped_to(:user_id).
+        with_message("already has an entry")
+    end
     it { should validate_presence_of(:user).with_message("must exist") }
     it { should validate_presence_of(:date) }
     it { should have_many(:goals) }
-  end
-
-  describe "#add_goals" do
-    it "adds goals to an entry" do
-      entry = build(:entry)
-      goals = Array.new(3) { Faker::Lorem.sentence }
-
-      entry.add_goals(goals)
-
-      expect(entry.goals.pluck(:description).sort).to eq goals.sort
-    end
-  end
-
-  describe "#add_goal" do
-    it "adds a goal to an entry" do
-      entry = build(:entry)
-      goal_description = Faker::Lorem.sentence
-
-      entry.add_goal(goal_description)
-
-      expect(entry.goals.pluck(:description)).to include goal_description
-    end
   end
 end


### PR DESCRIPTION
This is refactoring, no new functionality has been introduced. Before we
were using a factory method in the Entry model Entry::create_entry to
create new entries and handle the logic of creating the goals which
belong to it. We've replaced that with a FormObject, EntryCreator, which is
responsible for creating an entry and it's dependent goals. This is a
better pattern, since it follows more closely the single responseibility
principle.

Also added is the error handling for when child goals have model level
invalidations. This was made easy since we had introduced the
FormObject.