### PR TITLE
Add feature for deleting entries

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -7,6 +7,7 @@ class EntriesController < ApplicationController
     @entry_form = EntryForm.new
 
     if @entry_form.update_attributes(entry_form_params)
+      flash[:success] = "Entry has been created"
       redirect_to entry_path(@entry_form.entry)
     else
       flash.now[:error] = @entry_form.errors.full_messages
@@ -32,10 +33,23 @@ class EntriesController < ApplicationController
     @entry_form = EntryForm.new(entry: entry)
 
     if @entry_form.update_attributes(entry_form_params)
+      flash[:success] = "Entry has been updated"
       redirect_to entry_path(@entry_form.entry)
     else
       flash.now[:error] = @entry_form.errors.full_messages
       render :edit
+    end
+  end
+
+  def destroy
+    entry = current_user.entries.find_by(id: params[:id])
+    if entry.present?
+      entry.destroy
+      flash[:success] = "Entry has been deleted"
+      redirect_to entries_path
+    else
+      flash[:error] = "You are not authorized to delete this entry"
+      redirect_to entries_path
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ApplicationRecord
   include Clearance::User
+
+  has_many :entries
 end

--- a/app/views/entries/index.html.erb
+++ b/app/views/entries/index.html.erb
@@ -6,6 +6,7 @@
       <a
         href=<%= entry_path(entry) %>
         id=<%= "entry-id-#{entry.id}" %>
+        class="entry-item"
       >
         <%= entry.date %>
       </a>

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -10,4 +10,8 @@
 <% end %>
 </ul>
 
-<a href="<%= edit_entry_path(@entry)%>">Edit Entry</a>
+<% if @entry.user == current_user %>
+  <a href="<%= edit_entry_path(@entry)%>">Edit Entry</a>
+  <%= button_to("Delete Entry", { action: "destroy", id: @entry.id },
+      method: "delete", data: { confirm: "Are you sure?", disable_with: "loading..."}) %>
+<% end %>

--- a/spec/features/user_creates_todays_entry_spec.rb
+++ b/spec/features/user_creates_todays_entry_spec.rb
@@ -38,21 +38,21 @@ RSpec.feature "User creates a journal entry" do
     error_message = "Description is too long (maximum is 255 characters)"
     expect(page).to have_error_message(error_message)
   end
-end
 
-def create_entry(date: Date.today, goal1: nil, goal2: nil, goal3: nil)
-  visit new_entry_path
-  fill_in "entry-date", with: date
-  fill_in "Goal 1", with: goal1 || Faker::Lorem.sentence
-  fill_in "Goal 2", with: goal2 || Faker::Lorem.sentence
-  fill_in "Goal 3", with: goal3 || Faker::Lorem.sentence
-  click_on "Create Entry"
-end
+  def create_entry(date: Date.today, goal1: nil, goal2: nil, goal3: nil)
+    visit new_entry_path
+    fill_in "entry-date", with: date
+    fill_in "Goal 1", with: goal1 || Faker::Lorem.sentence
+    fill_in "Goal 2", with: goal2 || Faker::Lorem.sentence
+    fill_in "Goal 3", with: goal3 || Faker::Lorem.sentence
+    click_on "Create Entry"
+  end
 
-def have_goal_summary(goal)
-  have_css(".goal-summary", text: goal)
-end
+  def have_goal_summary(goal)
+    have_css(".goal-summary", text: goal)
+  end
 
-def have_error_message(message)
-  have_css(".flash-error", text: message)
+  def have_error_message(message)
+    have_css(".flash-error", text: message)
+  end
 end

--- a/spec/features/user_deletes_an_entry_spec.rb
+++ b/spec/features/user_deletes_an_entry_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require 'support/features/clearance_helpers'
+
+RSpec.feature "User deletes a journal entry" do
+  def have_entry_item_by_date(date)
+    have_css(".entry-item", text: date.to_s)
+  end
+
+  def have_success_message(message)
+    have_css(".flash-success", text: message)
+  end
+
+  scenario "deletes an entry" do
+    todays_date = Date.today
+    tomorrows_date = todays_date.next_day
+    user = create(:user)
+    entry_to_delete = Entry.create(date: todays_date, user: user)
+    entry_to_not_delete = Entry.create(date: tomorrows_date, user: user)
+
+    visit entry_path(entry_to_delete, as: user)
+    click_on "Delete Entry"
+
+    expect(page).to have_content("Entries Index")
+    expect(page).to have_success_message("Entry has been deleted")
+    expect(page).to_not have_entry_item_by_date(todays_date)
+    expect(page).to have_entry_item_by_date(tomorrows_date)
+  end
+end

--- a/spec/features/user_edits_an_entry_spec.rb
+++ b/spec/features/user_edits_an_entry_spec.rb
@@ -11,11 +11,11 @@ RSpec.feature "User edits and entry" do
     final_goal2 = Faker::Lorem.sentence
     todays_date = Date.today
 
-    user = sign_in
+    user = create(:user)
     entry_to_edit =
       Entry.create(date: todays_date, goals: initial_goals, user: user)
 
-    visit entries_path
+    visit entries_path(as: user)
     click_on "entry-id-#{entry_to_edit.id}"
     expect(page).to have_content("Entry Show Page")
     expect(page).to have_content(entry_to_edit.date)
@@ -36,22 +36,22 @@ RSpec.feature "User edits and entry" do
   scenario "trys to edit an entry with invalid form data" do
     todays_date = Date.today
     tomorrows_date = todays_date.next_day
-    user = sign_in
+    user = create(:user)
     entry_to_edit = Entry.create(date: tomorrows_date, user: user)
     Entry.create(date: todays_date, user: user)
 
-    visit edit_entry_path(entry_to_edit)
+    visit edit_entry_path(entry_to_edit, as: user)
     fill_in "entry-date", with: todays_date
     click_on "Submit Edit Entry"
 
     expect(page).to have_error_message("Date already has an entry")
   end
-end
 
-def have_goal_summary(goal)
-  have_css(".goal-summary", text: goal)
-end
+  def have_goal_summary(goal)
+    have_css(".goal-summary", text: goal)
+  end
 
-def have_error_message(message)
-  have_css(".flash-error", text: message)
+  def have_error_message(message)
+    have_css(".flash-error", text: message)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it { should have_many(:entries) }
+end

--- a/spec/requests/entries_request_spec.rb
+++ b/spec/requests/entries_request_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.describe "DELETE /entries/:id", type: :request do
+  context "the user owns the entry" do
+    it "deletes the entry" do
+      user = create(:user)
+      entry = create(:entry, user: user)
+
+      delete entry_path(entry, as: user)
+
+      expect(response).to redirect_to entries_path
+      expect(Entry.exists?(entry.id)).to eq false
+    end
+  end
+
+  context "the user does not own the entry" do
+    it "doesn't delete the entry" do
+      other_user = create(:user)
+      other_users_entry = create(:entry, user: other_user)
+      current_user = create(:user)
+
+      delete entry_path(other_users_entry, as: current_user)
+
+      expect(response).to redirect_to entries_path
+      expect(Entry.exists?(other_users_entry.id)).to eq true
+    end
+  end
+end

--- a/spec/views/entries/show.html.erb_spec.rb
+++ b/spec/views/entries/show.html.erb_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "entries/show.html.erb" do
+  context "the current user is the owner of the entry" do
+    it "renders the edit and delete buttons" do
+      user = build_stubbed(:user)
+      entry = build_stubbed(:entry, user: user)
+      render_entry(entry, current_user: user)
+
+      expect(rendered).to have_selector(:link_or_button, "Edit Entry")
+      expect(rendered).to have_selector(:link_or_button, "Delete Entry")
+    end
+  end
+
+  context "the current user is not the owner of the entry" do
+    it "doesn't render edit or delete buttons" do
+      current_user = build_stubbed(:user)
+      other_user = build_stubbed(:user)
+      other_users_entry = build_stubbed(:entry, user: other_user)
+      render_entry(other_users_entry, current_user: current_user)
+
+      expect(rendered).to_not have_selector(:link_or_button, "Edit Entry")
+      expect(rendered).to_not have_selector(:link_or_button, "Delete Entry")
+    end
+  end
+
+  def render_entry(entry, current_user: nil)
+    assign(:entry, entry)
+    assign(:current_user, current_user)
+
+    render
+  end
+end


### PR DESCRIPTION
This allows users to delete there own entries.

~~~It only prevents users from seeing the delete or edit buttons on other users entries. There is no authorization happening at the controller level to verify a user actually owns an entry before deleting it, so technically any user could post to the app and delete stuff they shouldn't be able to.~~~