### PR TITLE
Js daily notes feature

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@
 
 @import "base/base";
 @import "refills/flashes";
+@import "entry";

--- a/app/assets/stylesheets/entry.scss
+++ b/app/assets/stylesheets/entry.scss
@@ -1,0 +1,4 @@
+.note-content {
+  min-height: 400px;
+  width: 60%;
+}

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -17,6 +17,7 @@ class EntriesController < ApplicationController
 
   def show
     @entry = Entry.find(params[:id])
+    @note = @entry.note || Note.new(entry: @entry, content: "")
   end
 
   def index

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,41 @@
+class NotesController < ApplicationController
+  before_action :require_entry_to_belong_to_user
+
+  def create
+    @entry = entry
+    note = Note.new(content: note_params[:content], entry: @entry)
+    persist_note_and_redirect(note: note, entry: @entry, params: note_params)
+  end
+
+  def update
+    @entry = entry
+    note = @entry.note
+    persist_note_and_redirect(note: note, entry: @entry, params: note_params)
+  end
+
+  private
+
+  def note_params
+    params.require(:note).permit(:content)
+  end
+
+  def require_entry_to_belong_to_user
+    unless entry.user == current_user
+      flash[:error] = "Entry does not belong to you"
+      redirect_to entries_path
+    end
+  end
+
+  def persist_note_and_redirect(note:, entry:, params:)
+    if note.update_attributes(params)
+      flash[:success] = "Note Saved"
+    else
+      flash[:error] = note.errors.full_messages
+    end
+    redirect_to entry_path(entry)
+  end
+
+  def entry
+    @_entry_for_notes ||= Entry.find(params[:entry_id])
+  end
+end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -4,6 +4,7 @@ class Entry < ApplicationRecord
   validates :date, presence: true
 
   has_many :goals, -> { order(id: :asc) }, dependent: :destroy
+  has_one :note, dependent: :destroy
   belongs_to :user
 
   def goal_descriptions

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,7 @@
+class Note < ApplicationRecord
+  validates :content,
+    length: { minimum: 0, allow_nil: false, message: "can't be nil" }
+  validates :entry_id, uniqueness: true
+
+  belongs_to :entry
+end

--- a/app/views/entries/_note_form.html.erb
+++ b/app/views/entries/_note_form.html.erb
@@ -1,0 +1,12 @@
+<% if note.new_record? %>
+  <% action_url = entry_notes_path(entry) %>
+<% else %>
+  <% action_url = entry_note_path(entry, note) %>
+<% end %>
+
+<%= form_for note, url: action_url do |note_form| %>
+  <%= label :note, :content, "Notes: " %>
+  <%= note_form.text_area :content, class: "note-content" %>
+  <%= note_form.submit "Save Notes" %>
+<% end %>
+

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -10,6 +10,8 @@
 <% end %>
 </ul>
 
+<%= render "note_form", note: @note, entry: @entry %>
+
 <% if @entry.user == current_user %>
   <a href="<%= edit_entry_path(@entry)%>">Edit Entry</a>
   <%= button_to("Delete Entry", { action: "destroy", id: @entry.id },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   get '/pages/*id' => 'pages#show', format: false
 
-  resources :entries
+  resources :entries do
+    resources :notes, only: %i(create update)
+  end
   root to: 'pages#show', id: 'home'
 end

--- a/db/migrate/20180414182919_create_notes.rb
+++ b/db/migrate/20180414182919_create_notes.rb
@@ -1,0 +1,13 @@
+class CreateNotes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :notes do |t|
+      t.string :content, null: false
+      t.integer :entry_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :notes, :entry_id, unique: true
+    add_foreign_key :notes, :entries
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180403131633) do
+ActiveRecord::Schema.define(version: 20180414182919) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,14 @@ ActiveRecord::Schema.define(version: 20180403131633) do
     t.index ["entry_id"], name: "index_goals_on_entry_id"
   end
 
+  create_table "notes", force: :cascade do |t|
+    t.string "content", null: false
+    t.integer "entry_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entry_id"], name: "index_notes_on_entry_id", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -58,4 +66,5 @@ ActiveRecord::Schema.define(version: 20180403131633) do
   end
 
   add_foreign_key "goals", "entries"
+  add_foreign_key "notes", "entries"
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe PagesController, type: :controller do
-
-end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :note do
+    content { Faker::Lorem.paragraph }
+    entry
+  end
+end

--- a/spec/features/entry_notes_spec.rb
+++ b/spec/features/entry_notes_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Entry Notes" do
+  scenario "user alters existing notes" do
+    user = create(:user)
+    entry = create(:entry, user: user)
+    original_note_content = Faker::Lorem.paragraph
+    create(:note, entry: entry, content: original_note_content)
+    new_note_content = Faker::Lorem.paragraph
+
+    visit entry_path(entry, as: user)
+    expect(page).to have_content(original_note_content)
+
+    fill_in "Notes", with: new_note_content
+    click_on "Save Notes"
+
+    expect(page).to have_content("Note Saved")
+    expect(page).to have_content(new_note_content)
+  end
+
+  scenario "user writes new notes on todays entry" do
+    todays_date = Date.today
+    user = create(:user)
+    entry = Entry.create(date: todays_date, user: user)
+    notes_text = Faker::Lorem.paragraph
+
+    visit entry_path(entry, as: user)
+    fill_in "Notes", with: notes_text
+    click_on "Save Notes"
+
+    expect(page).to have_content(notes_text)
+
+    user_leaves_and_revisits_entry_page(entry)
+    expect(page).to have_content(notes_text)
+  end
+
+  def user_leaves_and_revisits_entry_page(entry)
+    visit entries_path
+    visit entry_path(entry)
+  end
+end

--- a/spec/features/user_edits_an_entry_spec.rb
+++ b/spec/features/user_edits_an_entry_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'support/features/clearance_helpers'
 
-RSpec.feature "User edits and entry" do
+RSpec.feature "User edits an entry" do
   scenario "edits an entry" do
     initial_goal1 = build(:goal, description: Faker::Lorem.sentence)
     initial_goal2 = build(:goal, description: Faker::Lorem.sentence)

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe Entry, type: :model do
     it { should validate_presence_of(:user).with_message("must exist") }
     it { should validate_presence_of(:date) }
     it { should have_many(:goals) }
+    it { should have_one(:note) }
   end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Note, type: :model do
+  let(:entry) { create(:entry) }
+  subject { Note.create(entry: entry, content: "Here is the content") }
+
+  it { should belong_to(:entry) }
+  it { should allow_value("").for(:content) }
+  it { should_not allow_value(nil).for(:content) }
+  it { should validate_uniqueness_of(:entry_id) }
+end

--- a/spec/requests/entry_notes/post_entry_notes_request_spec.rb
+++ b/spec/requests/entry_notes/post_entry_notes_request_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.describe "POST /entries/:id/notes", type: :request do
+  context "the user owns the entry" do
+    it "creates a new note" do
+      user = create(:user)
+      entry = create(:entry, user: user)
+      note_content = Faker::Lorem.paragraph
+
+      post entry_notes_path(entry, as: user),
+        params: { note: { content: note_content } }
+
+      expect(entry.note).to be_persisted
+      expect(entry.note.content).to eq note_content
+    end
+  end
+
+  context "the user does note own the entry" do
+    it "rejects the request to create a new note" do
+      current_user = create(:user)
+      other_user = create(:user)
+      other_users_entry = create(:entry, user: other_user)
+      new_note_content = Faker::Lorem.paragraph
+
+      post entry_notes_path(other_users_entry, as: current_user),
+        params: { note: { content: new_note_content } }
+
+      expect(other_users_entry.note).to be nil
+    end
+  end
+end

--- a/spec/requests/entry_notes/put_entry_note_request_spec.rb
+++ b/spec/requests/entry_notes/put_entry_note_request_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.describe "PUT /entries/:entry_id/notes/:id", type: :request do
+  context "the user owns the entry" do
+    it "updates the note" do
+      user = create(:user)
+      entry = create(:entry, user: user)
+      original_note_content = Faker::Lorem.paragraph
+      note = create(:note, entry: entry, content: original_note_content)
+      new_note_content = Faker::Lorem.paragraph
+
+      put entry_note_path(entry, note, as: user),
+          params: { note: { content: new_note_content } }
+
+      entry.note.reload
+      expect(entry.note.content).to eq new_note_content
+    end
+  end
+
+  context "the user does not own the entry" do
+    it "rejects the request to update and doesn't edit a note" do
+      user = create(:user)
+      other_user = create(:user)
+      other_users_entry = create(:entry, user: other_user)
+      original_note_content = Faker::Lorem.paragraph
+      other_users_note = create(:note, entry: other_users_entry,
+                                       content: original_note_content)
+      new_note_content = Faker::Lorem.paragraph
+
+      put entry_note_path(other_users_entry, other_users_note, as: user),
+        params: { note: { content: new_note_content } }
+
+      other_users_entry.note.reload
+      expect(other_users_entry.note.content).to eq original_note_content
+    end
+  end
+end

--- a/spec/views/entries/show.html.erb_spec.rb
+++ b/spec/views/entries/show.html.erb_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "entries/show.html.erb" do
   def render_entry(entry, current_user: nil)
     assign(:entry, entry)
     assign(:current_user, current_user)
+    assign(:note, Note.new(entry: entry, content: ""))
 
     render
   end


### PR DESCRIPTION
Relatively simple feature, nothing too crazy, but i did have two questions that would be nice to chat about irl.

### Q1: 
what are thoughtbot's thoughts on before_action filters in controllers?

I looked but could only find this: https://robots.thoughtbot.com/before-filter-wisdom which doesn't seem to have an opinion.  The reason I asks is because after watching this upcase video: 

https://thoughtbot.com/upcase/videos/thoughtbots-approach-to-ruby

there is a lot of discussion about making code not hide complexity by using fancy ruby tricks, like ternaries, or end of line if statements.  Wouldn't before_filters in controllers fall into category as well?  Though using them allows the controller to tell a more easily followable story.

---

### Q2:
would it make more sense to only have the notes#update action and initialize a note on entry creation?
or to have an notes#create action and a notes#update action and have a conditional in the controller to choose which?

I like having the notes controller be responsible for both creation and updating of notes, because it feels like breaking single responsibility to have the entries or entry_form objects to handle creation of notes. (unless we allow notes on the new/edit entry forms, which i don't want from a ux perspective) Though doing this might save us from having nil checks and conditionals in the views/controllers, since the note will always exist.

another option would be to have the create action delete the previous note and have it act as a update, (also don't like this due to obfuscation of what create means)