### PR TITLE
Stop rendering blank goals on entry page

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -17,6 +17,7 @@ class EntriesController < ApplicationController
 
   def show
     @entry = Entry.find(params[:id])
+    @goals = @entry.goals.with_descriptions
     @note = @entry.note || Note.new(entry: @entry, content: "")
   end
 

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -1,6 +1,12 @@
 class Goal < ApplicationRecord
+  validates :description, length:
+    { minimum: 0, allow_nil: false, message: "can't be nil" }
   validates_length_of :description, maximum: 255
   validates :completed, inclusion: { in: [true, false] }
 
   belongs_to :entry
+
+  def self.with_descriptions
+    where.not(description: "")
+  end
 end

--- a/app/views/entries/show.html.erb
+++ b/app/views/entries/show.html.erb
@@ -8,7 +8,7 @@
 <div class="entry-section">
   <h2>Goals:</h2>
   <ul class="goal-list">
-  <% @entry.goals.each do |goal| %>
+  <% @goals.each do |goal| %>
     <% goal_id = "goal-#{goal.id}" %>
     <li class="goal-summary" >
       <label class="goal-checkbox-label">

--- a/db/migrate/20180424171621_add_null_constraint_to_goals.rb
+++ b/db/migrate/20180424171621_add_null_constraint_to_goals.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintToGoals < ActiveRecord::Migration[5.1]
+  def change
+    change_column :goals, :description, :string, null: false, default: "", limit: 255
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180417200849) do
+ActiveRecord::Schema.define(version: 20180424171621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 20180417200849) do
   end
 
   create_table "goals", force: :cascade do |t|
-    t.string "description", limit: 255
+    t.string "description", limit: 255, default: "", null: false
     t.integer "entry_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/entry.rb
+++ b/spec/factories/entry.rb
@@ -2,5 +2,15 @@ FactoryBot.define do
   factory :entry do
     date { Time.now }
     user
+
+    factory :entry_with_goals do
+      transient do
+        goals_count 3
+      end
+
+      after(:create) do |entry, evaluator|
+        create_list(:goal, evaluator.goals_count, entry: entry)
+      end
+    end
   end
 end

--- a/spec/factories/goals.rb
+++ b/spec/factories/goals.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     trait :uncompleted do
       completed false
     end
+
+    trait :blank do
+      description ""
+    end
   end
 end

--- a/spec/models/goal_spec.rb
+++ b/spec/models/goal_spec.rb
@@ -2,5 +2,21 @@ require "rails_helper"
 
 RSpec.describe Goal, type: :model do
   it { should belong_to(:entry) }
+  it { should validate_presence_of(:description).with_message("can't be nil") }
+  it { should allow_value("").for(:description) }
   it { should validate_length_of(:description).is_at_most(255) }
+
+  describe ".with_descriptions" do
+    it "includes goals with descriptions" do
+      goal = create(:goal)
+
+      expect(Goal.with_descriptions).to include goal
+    end
+
+    it "excludes goals without descriptions" do
+      blank_goal = create(:goal, :blank)
+
+      expect(Goal.with_descriptions).to_not include blank_goal
+    end
+  end
 end

--- a/spec/requests/get_entry_request_spec.rb
+++ b/spec/requests/get_entry_request_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "GET /entry/:id", type: :request do
+  it "doesn't return blank goals" do
+    goals_count = 2
+    entry = create(:entry_with_goals, goals_count: goals_count)
+    create(:goal, :blank, entry: entry)
+
+    get entry_path(entry)
+
+    expect(count_of_goals_in_response).to eq goals_count
+  end
+
+  def count_of_goals_in_response
+    response.body.scan("goal-summary").size
+  end
+end

--- a/spec/views/entries/show.html.erb_spec.rb
+++ b/spec/views/entries/show.html.erb_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "entries/show.html.erb" do
+  it "correctly renders an entry's goals" do
+    user = build_stubbed(:user)
+    entry = create(:entry_with_goals, goals_count: 3, user: user)
+    render_entry(entry, current_user: user)
+
+    expect(rendered).to have_goal_list_items(count: 3)
+  end
+
   context "the current user is the owner of the entry" do
     it "renders the edit and delete buttons" do
       user = build_stubbed(:user)
@@ -28,7 +36,12 @@ RSpec.describe "entries/show.html.erb" do
     assign(:entry, entry)
     assign(:current_user, current_user)
     assign(:note, Note.new(entry: entry, content: ""))
+    assign(:goals, entry.goals)
 
     render
+  end
+
+  def have_goal_list_items(count: 1)
+    have_selector("li.goal-summary", count: count)
   end
 end


### PR DESCRIPTION
Before, if a user saves a goal with a blank description, the goal would
still render a checkbox with no text.

This commit filter any goals that have blank descriptions out before rendering the entry show page.

---

### Before:
![blank goals - before](https://user-images.githubusercontent.com/16049495/39098574-66a5712a-4632-11e8-8353-ded62e5bfc9f.gif)

### After: 

![blank goals - after](https://user-images.githubusercontent.com/16049495/39098576-6e5d69cc-4632-11e8-86ca-d221dd7759e0.gif)
