### PR TITLE
Js add note to entry form

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -18,7 +18,7 @@ class EntriesController < ApplicationController
   def show
     @entry = Entry.find(params[:id])
     @goals = @entry.goals.with_descriptions
-    @note = @entry.note || Note.new(entry: @entry, content: "")
+    @note = @entry.note
   end
 
   def index

--- a/app/views/entries/_note_form.html.erb
+++ b/app/views/entries/_note_form.html.erb
@@ -1,10 +1,4 @@
-<% if note.new_record? %>
-  <% action_url = entry_notes_path(entry) %>
-<% else %>
-  <% action_url = entry_note_path(entry, note) %>
-<% end %>
-
-<%= form_for note, url: action_url do |note_form| %>
+<%= form_for note, url: entry_note_path(entry, note) do |note_form| %>
   <%= note_form.text_area :content, class: "note-content" %>
   <%= note_form.submit "Save Notes" %>
 <% end %>

--- a/app/views/user_mailer/weekly_summary.html.erb
+++ b/app/views/user_mailer/weekly_summary.html.erb
@@ -9,14 +9,12 @@
       <h3>Notes from last week:</h3>
       <ul>
         <% @entries.each do |entry| %>
-          <% if entry.note %>
           <li>
             <div>
               <div>date: <%= entry.date %></div>
               <div>content: <%= entry.note.content %></div>
             </div>
           </li>
-          <% end %>
         <% end %>
       </ul>
     </div>

--- a/app/views/user_mailer/weekly_summary.text.erb
+++ b/app/views/user_mailer/weekly_summary.text.erb
@@ -4,7 +4,5 @@ Here is your weekly summary
 Notes from last week:
 <% @entries.each do |entry| %>
   <%= entry.date %>
-  <% if entry.note %>
-    <%= entry.note.content %>
-  <% end %>
+  <%= entry.note.content %>
 <% end %>

--- a/spec/factories/entry.rb
+++ b/spec/factories/entry.rb
@@ -3,7 +3,17 @@ FactoryBot.define do
     date { Time.now }
     user
 
-    factory :entry_with_goals do
+    trait :with_note do
+      transient do
+        note_content { Faker::Lorem.sentence }
+      end
+
+      after(:create) do |entry, evaluator|
+        create(:note, entry: entry, content: evaluator.note_content)
+      end
+    end
+
+    trait :with_goals do
       transient do
         goals_count 3
       end

--- a/spec/features/entry_notes_spec.rb
+++ b/spec/features/entry_notes_spec.rb
@@ -4,9 +4,11 @@ require "support/features/clearance_helpers"
 RSpec.feature "Entry Notes" do
   scenario "user alters existing notes" do
     user = create(:user)
-    entry = create(:entry, user: user)
     original_note_content = Faker::Lorem.paragraph
-    create(:note, entry: entry, content: original_note_content)
+    entry = create(:entry,
+                   :with_note,
+                   user: user,
+                   note_content: original_note_content)
     new_note_content = Faker::Lorem.paragraph
 
     visit entry_path(entry, as: user)
@@ -24,7 +26,7 @@ RSpec.feature "Entry Notes" do
     stub_api_request
     todays_date = Date.today
     user = create(:user)
-    entry = Entry.create(date: todays_date, user: user)
+    entry = create(:entry, :with_note, date: todays_date, user: user)
     notes_text = Faker::Lorem.paragraph
 
     visit entry_path(entry, as: user)

--- a/spec/features/user_completes_a_goal_spec.rb
+++ b/spec/features/user_completes_a_goal_spec.rb
@@ -4,7 +4,7 @@ require "support/features/clearance_helpers"
 RSpec.feature "User completes a goal" do
   scenario "User clicks an uncomplete goal", js: true do
     user = create(:user)
-    entry = create(:entry, user: user)
+    entry = create(:entry, :with_note, user: user)
     goal1_description = Faker::Lorem.sentence
     goal1 = create(:goal, :uncompleted, entry: entry,
                                         description: goal1_description)
@@ -26,7 +26,7 @@ RSpec.feature "User completes a goal" do
   end
 
   scenario "Goals that are completed show as checked" do
-    entry = create(:entry)
+    entry = create(:entry, :with_note)
     completed_goal = create(:goal, :completed, entry: entry)
     uncompleted_goal = create(:goal, :uncompleted, entry: entry)
     completed_checkbox_selector = "input#goal-#{completed_goal.id}"

--- a/spec/features/user_deletes_an_entry_spec.rb
+++ b/spec/features/user_deletes_an_entry_spec.rb
@@ -15,8 +15,8 @@ RSpec.feature "User deletes a journal entry" do
     todays_date = Date.today
     tomorrows_date = todays_date.next_day
     user = create(:user)
-    entry_to_delete = Entry.create(date: todays_date, user: user)
-    Entry.create(date: tomorrows_date, user: user)
+    entry_to_delete = create(:entry, :with_note, date: todays_date, user: user)
+    create(:entry, :with_note, date: tomorrows_date, user: user)
 
     visit entry_path(entry_to_delete, as: user)
     click_on "Delete Entry"

--- a/spec/features/user_edits_an_entry_spec.rb
+++ b/spec/features/user_edits_an_entry_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "User edits an entry" do
 
     user = create(:user)
     entry_to_edit =
-      Entry.create(date: todays_date, goals: initial_goals, user: user)
+      create(:entry, :with_goals, :with_note, goals: initial_goals, user: user)
 
     visit entries_path(as: user)
     click_on "entry-id-#{entry_to_edit.id}"

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -23,12 +23,11 @@ RSpec.describe UserMailer, type: :mailer do
     it "should contain the users notes from last week" do
       user = create(:user)
       date = 1.day.ago
-      entry = create(:entry, user: user, date: date)
-      note = create(:note, entry: entry)
+      entry = create(:entry, :with_note, user: user, date: date)
       email = UserMailer.with(user: user).weekly_summary
 
       expect(email).to have_body_text(date.strftime("%Y-%m-%d"))
-      expect(email).to have_body_text(note.content)
+      expect(email).to have_body_text(entry.note.content)
     end
   end
 end

--- a/spec/models/entry_form_spec.rb
+++ b/spec/models/entry_form_spec.rb
@@ -1,11 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "EntryForm" do
-  it "initializes with a blank entry and three blank goals" do
+  it "initializes with a blank entry, a note, and three blank goals" do
     entry_form = EntryForm.new
 
     expect(entry_form.entry).to be_a_kind_of(Entry)
     expect(entry_form.goals.length).to eq 3
     expect(entry_form.goals.first).to be_a_kind_of(Goal)
+    expect(entry_form.note).to be_a_kind_of(Note)
   end
 end

--- a/spec/requests/get_entry_request_spec.rb
+++ b/spec/requests/get_entry_request_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "GET /entry/:id", type: :request do
   it "doesn't return blank goals" do
     goals_count = 2
-    entry = create(:entry_with_goals, goals_count: goals_count)
+    entry = create(:entry, :with_note, :with_goals, goals_count: goals_count)
     create(:goal, :blank, entry: entry)
 
     get entry_path(entry)

--- a/spec/views/entries/show.html.erb_spec.rb
+++ b/spec/views/entries/show.html.erb_spec.rb
@@ -3,8 +3,9 @@ require "rails_helper"
 RSpec.describe "entries/show.html.erb" do
   it "correctly renders an entry's goals" do
     user = build_stubbed(:user)
-    entry = create(:entry_with_goals, goals_count: 3, user: user)
-    render_entry(entry, current_user: user)
+    entry = create(:entry, :with_goals, goals_count: 3, user: user)
+    note = build_stubbed(:note, entry: entry)
+    render_entry(entry, note, current_user: user)
 
     expect(rendered).to have_goal_list_items(count: 3)
   end
@@ -13,7 +14,8 @@ RSpec.describe "entries/show.html.erb" do
     it "renders the edit and delete buttons" do
       user = build_stubbed(:user)
       entry = build_stubbed(:entry, user: user)
-      render_entry(entry, current_user: user)
+      note = build_stubbed(:note, entry: entry)
+      render_entry(entry, note, current_user: user)
 
       expect(rendered).to have_selector(:link_or_button, "Edit Entry")
       expect(rendered).to have_selector(:link_or_button, "Delete Entry")
@@ -25,17 +27,19 @@ RSpec.describe "entries/show.html.erb" do
       current_user = build_stubbed(:user)
       other_user = build_stubbed(:user)
       other_users_entry = build_stubbed(:entry, user: other_user)
-      render_entry(other_users_entry, current_user: current_user)
+      other_users_note = build_stubbed(:note, entry: other_users_entry)
+      render_entry(other_users_entry, other_users_note,
+                   current_user: current_user)
 
       expect(rendered).to_not have_selector(:link_or_button, "Edit Entry")
       expect(rendered).to_not have_selector(:link_or_button, "Delete Entry")
     end
   end
 
-  def render_entry(entry, current_user: nil)
+  def render_entry(entry, note, current_user: nil)
     assign(:entry, entry)
     assign(:current_user, current_user)
-    assign(:note, Note.new(entry: entry, content: ""))
+    assign(:note, note)
     assign(:goals, entry.goals)
 
     render


### PR DESCRIPTION
This one doesn't add any new functionality, just paying off some tech debt.  

The form object for entries now creates a blank note on initialization, which allows to us to remove some nil checking/conditional logic from the view layer.  

It also cleans up the entry factory to use traits so that it is more flexible and can be initialized with notes or with goals.

It was pretty easy to extend the form object to do this, but i wanted to chat about it a bit: another alternative to this problem of creating a note on entry initialization could have be done using an before_save callback or similar.  I chose not to do this because it seemed a lot messier.  Was this the better call?  or is there a reason I would not want to use a form object to handle this kind of stuff?